### PR TITLE
Fix up printing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -102,8 +102,7 @@ Commands:
         DROP COLUMN <column-name> |
         ADD RANGE PARTITION (<col-val>, ..) <= VALUES < (<col-val>, ..) |
         DROP RANGE PARTITION (<col-val>, ..) <= VALUES < (<col-val>, ..)
-    ], ..;
-";
+    ], ..;";
 
 /*
     SELECT * FROM <table>;


### PR DESCRIPTION
This fixes up the printing a little bit:

* Uniformizes when there are empty lines after output on stderr and
  stdout. There use to be extra blank lines sometimes, but now there
  aren't. This seemed consistent with other command-line tools, in
  particular rustc, which produces similar error messages to ksql's parse
  errors.
* Refactors some functions to share terminal set + reset code.
* Adds the table name to add/drop/alter success responses.
* Uniformizes when stderr messages are bold. It seemed like the intent
  was they all should be.
* QoL improvement in print_parse_error that eliminated an unnecessary
  length check, allowing most of the function to drop one level of
  indentation.

Testing: The existing tests appear to be broken :( but I did try out successful, unsuccessful, and malformed SHOW TABLES and CREATE/DROP TABLES commands to make sure the output looked as expected. I also checked the HELP command since I changed the literal.